### PR TITLE
🔃 refactor all cryptocompare API calls

### DIFF
--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "CryptoCharts",
+  "name": "CryptoCharts MERN Project",
   "icons": [
     {
       "src": "favicon.ico",

--- a/client/src/_components/charter/CoinCard.jsx
+++ b/client/src/_components/charter/CoinCard.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
+  fetchCharterData,
   fetchCoinInfo,
   fetchHistory,
   setActiveCoinId,
@@ -31,10 +32,15 @@ const CoinCard = ({ coin, deleteCoin, setError }) => {
     e.stopPropagation();
     if (isActive) return;
     dispatch(setActiveCoinId(coin._id));
+    /* 
     dispatch(fetchCoinInfo(coin.symbol));
     dispatch(
       fetchHistory({ coinSymbol: coin.symbol, timeframe: activeTimeframe })
     );
+    */
+
+    // TODO: fetchCharterData should fetch both info and history
+    dispatch(fetchCharterData({ coin, timeframe: activeTimeframe }));
   };
 
   return (

--- a/client/src/_components/charter/CoinCard.jsx
+++ b/client/src/_components/charter/CoinCard.jsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   fetchCharterData,
-  fetchCoinInfo,
-  fetchHistory,
   setActiveCoinId,
   selectHistory,
 } from "../../_store/reducers/historySlice";
@@ -32,14 +30,6 @@ const CoinCard = ({ coin, deleteCoin, setError }) => {
     e.stopPropagation();
     if (isActive) return;
     dispatch(setActiveCoinId(coin._id));
-    /* 
-    dispatch(fetchCoinInfo(coin.symbol));
-    dispatch(
-      fetchHistory({ coinSymbol: coin.symbol, timeframe: activeTimeframe })
-    );
-    */
-
-    // TODO: fetchCharterData should fetch both info and history
     dispatch(fetchCharterData({ coin, timeframe: activeTimeframe }));
   };
 

--- a/client/src/_store/reducers/coinListSlice.js
+++ b/client/src/_store/reducers/coinListSlice.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getAllCoins } from "../../lib/cryptocompareAPI";
 
 // TODO: add ts types for status
 // initialState.status options: 'idle' | 'loading' | 'succeeded' | 'failed'
@@ -69,27 +70,20 @@ export const fetchCoins = createAsyncThunk("coinList/fetchCoins", async () => {
 export const addNewCoin = createAsyncThunk(
   "coinList/addNewCoin",
   async (newCoinSymbol) => {
-    const sym = newCoinSymbol.toUpperCase();
-    let cryptocompareRes;
-    try {
-      cryptocompareRes = await axios.get(
-        "https://min-api.cryptocompare.com/data/all/coinlist"
-      );
-    } catch (err) {
-      console.error(err);
-      throw new Error("Error: failed to save new coin, please try again later");
-    }
-    const cryptoData = cryptocompareRes?.data?.Data[sym];
-    if (!cryptoData) {
+    const SYM = newCoinSymbol.toUpperCase();
+    const coins = await getAllCoins();
+    const coinFound = coins[SYM];
+
+    if (!coinFound) {
       throw new Error("A coin with that symbol does not exist");
     }
-    const data = {
-      coinName: cryptoData.CoinName,
-      cryptoCompareId: cryptoData.Id,
-      name: cryptoData.Name,
-      symbol: cryptoData.Symbol,
+    const newCoin = {
+      coinName: coinFound.CoinName,
+      cryptoCompareId: coinFound.Id,
+      name: coinFound.Name,
+      symbol: coinFound.Symbol,
     };
-    const res = await axios.put("/api/watchlist/public", data);
+    const res = await axios.put("/api/watchlist/public", newCoin);
     if (!res.data.success) {
       throw new Error("There was an error posting new coin data");
     }

--- a/client/src/_store/reducers/coinListSlice.js
+++ b/client/src/_store/reducers/coinListSlice.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { getCoinSummary } from "../../lib/cryptocompareAPI";
+import { getCoinDetails } from "../../lib/cryptocompareAPI";
 
 // TODO: add ts types for status
 // initialState.status options: 'idle' | 'loading' | 'succeeded' | 'failed'
@@ -71,7 +71,7 @@ export const addNewCoin = createAsyncThunk(
   "coinList/addNewCoin",
   async (newCoinSymbol) => {
     const SYM = newCoinSymbol.toUpperCase();
-    const coinFound = await getCoinSummary({ fromSymbol: SYM });
+    const coinFound = await getCoinDetails({ fromSymbol: SYM });
 
     const newCoin = {
       coinName: coinFound.CoinName,

--- a/client/src/_store/reducers/coinListSlice.js
+++ b/client/src/_store/reducers/coinListSlice.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { getAllCoins } from "../../lib/cryptocompareAPI";
+import { getCoinSummary } from "../../lib/cryptocompareAPI";
 
 // TODO: add ts types for status
 // initialState.status options: 'idle' | 'loading' | 'succeeded' | 'failed'
@@ -71,8 +71,7 @@ export const addNewCoin = createAsyncThunk(
   "coinList/addNewCoin",
   async (newCoinSymbol) => {
     const SYM = newCoinSymbol.toUpperCase();
-    const coins = await getAllCoins();
-    const coinFound = coins[SYM];
+    const coinFound = await getCoinSummary({ fromSymbol: SYM });
 
     if (!coinFound) {
       throw new Error("A coin with that symbol does not exist");
@@ -83,6 +82,7 @@ export const addNewCoin = createAsyncThunk(
       name: coinFound.Name,
       symbol: coinFound.Symbol,
     };
+
     const res = await axios.put("/api/watchlist/public", newCoin);
     if (!res.data.success) {
       throw new Error("There was an error posting new coin data");

--- a/client/src/_store/reducers/coinListSlice.js
+++ b/client/src/_store/reducers/coinListSlice.js
@@ -73,9 +73,6 @@ export const addNewCoin = createAsyncThunk(
     const SYM = newCoinSymbol.toUpperCase();
     const coinFound = await getCoinSummary({ fromSymbol: SYM });
 
-    if (!coinFound) {
-      throw new Error("A coin with that symbol does not exist");
-    }
     const newCoin = {
       coinName: coinFound.CoinName,
       cryptoCompareId: coinFound.Id,
@@ -87,6 +84,7 @@ export const addNewCoin = createAsyncThunk(
     if (!res.data.success) {
       throw new Error("There was an error posting new coin data");
     }
+
     const coin = res.data.data;
     return coin;
   }

--- a/client/src/_store/reducers/historySlice.js
+++ b/client/src/_store/reducers/historySlice.js
@@ -5,10 +5,12 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { getHisto } from "../../lib/timeframe";
+import { getCoinDailyAverageData } from "../../lib/cryptocompareAPI";
 
-// TODO: implement typescript - would make it clear what each data field is supposed to be.
-//  - idk if activeTimeframe is supposed to be an obj or a str
-//  - status: "idle" | "loading" | "succeeded" | "failed",
+// TODO: implement typescript - this would make it clear what each data field is supposed to be.
+//  - ie. `activeTimeframe` should be a string
+//  - `coinInfo` should be null or an object
+//  - `status`: "idle" | "loading" | "succeeded" | "failed",
 
 const initialState = {
   activeCoinId: null,
@@ -117,25 +119,12 @@ export const fetchHistory = createAsyncThunk(
   }
 );
 
-// GET the coin's daily trading average data from the cryptocompare api and save it to coinInfo state
 export const fetchCoinInfo = createAsyncThunk(
   "history/fetchCoinInfo",
   async (coinSymbol) => {
-    const res = await fetch(
-      `https://min-api.cryptocompare.com/data/generateAvg?fsym=${coinSymbol}&tsym=USD&e=Kraken`
-    );
+    const { DISPLAY } = await getCoinDailyAverageData(coinSymbol);
 
-    if (!res.ok) {
-      throw new Error("Error: something went wrong, please try again later 😢");
-    }
-
-    const data = await res.json();
-    if ((data?.Response && data.Response === "Error") || !data?.DISPLAY) {
-      throw new Error("Sorry! No market data available for this coin 😢");
-    }
-    const { DISPLAY } = data;
-
-    const dailyAverage = {
+    const coinInfo = {
       currentPrice: DISPLAY.PRICE,
       pctChange: DISPLAY.CHANGEPCT24HOUR,
       open: DISPLAY.OPEN24HOUR,
@@ -143,8 +132,7 @@ export const fetchCoinInfo = createAsyncThunk(
       low: DISPLAY.LOW24HOUR,
       usdChange: DISPLAY.CHANGE24HOUR,
     };
-
-    return dailyAverage;
+    return coinInfo;
   }
 );
 

--- a/client/src/_store/reducers/symbolsSlice.js
+++ b/client/src/_store/reducers/symbolsSlice.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { getAllCoins } from "../../lib/cryptocompareAPI";
+import { parseAllCoinSymbols } from "../../lib/transformers";
 
 export const symbolsSlice = createSlice({
   name: "symbols",
@@ -39,8 +40,7 @@ export const fetchSymbols = createAsyncThunk(
   "symbols/fetchSymbols",
   async () => {
     const allCoins = await getAllCoins();
-    const allCoinSymbols = Object.values(allCoins);
-    return allCoinSymbols;
+    return parseAllCoinSymbols(allCoins);
   }
 );
 

--- a/client/src/_store/reducers/symbolsSlice.js
+++ b/client/src/_store/reducers/symbolsSlice.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getAllCoins } from "../../lib/cryptocompareAPI";
 
 export const symbolsSlice = createSlice({
   name: "symbols",
@@ -37,14 +38,9 @@ export const { setSymbols, setStatus } = symbolsSlice.actions;
 export const fetchSymbols = createAsyncThunk(
   "symbols/fetchSymbols",
   async () => {
-    const res = await axios.get(
-      "https://min-api.cryptocompare.com/data/all/coinlist?summary=true"
-    );
-    if (!res.data?.Data) {
-      throw new Error("Something went wrong while getting symbol");
-    }
-    const initialSymbols = Object.values(res.data.Data);
-    return initialSymbols;
+    const allCoins = await getAllCoins();
+    const allCoinSymbols = Object.values(allCoins);
+    return allCoinSymbols;
   }
 );
 

--- a/client/src/_store/reducers/watchListSlice.js
+++ b/client/src/_store/reducers/watchListSlice.js
@@ -3,7 +3,7 @@ This is the Redux state slice for state related to the personal watchlist of a u
 */
 import axios from "axios";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { getCoinSummary } from "../../lib/cryptocompareAPI";
+import { getCoinDetails } from "../../lib/cryptocompareAPI";
 
 const initialState = {
   coins: [],
@@ -65,12 +65,11 @@ export const fetchWatchlist = createAsyncThunk(
   }
 );
 
-// todo: refactor get call to https://min-api.cryptocompare.com/data/all/coinlist, its repeated a lot in the app
 export const addNewCoin = createAsyncThunk(
   "watchList/addNewCoin",
   async (newCoinSymbol) => {
     const SYM = newCoinSymbol.toUpperCase();
-    const coinFound = await getCoinSummary({ fromSymbol: SYM });
+    const coinFound = await getCoinDetails({ fromSymbol: SYM });
 
     const newCoin = {
       coinName: coinFound.CoinName,

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -2,7 +2,6 @@ export async function getCoinDailyAverageData(coinSymbol) {
   const res = await fetch(
     `https://min-api.cryptocompare.com/data/generateAvg?fsym=${coinSymbol}&tsym=USD&e=Kraken`
   );
-
   if (!res.ok) {
     throw new Error("Error: something went wrong, please try again later 😢");
   }
@@ -27,6 +26,5 @@ export async function getCoinHistory({ coinSymbol, timeUnit, limit }) {
   if (data?.Response !== "Success" || !data?.Data) {
     throw new Error("Sorry! No market data available for this coin 😢");
   }
-
   return data;
 }

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -13,3 +13,20 @@ export async function getCoinDailyAverageData(coinSymbol) {
   }
   return data;
 }
+
+export async function getCoinHistory({ coinSymbol, timeUnit, limit }) {
+  const res = await fetch(
+    `https://min-api.cryptocompare.com/data/${timeUnit}?fsym=${coinSymbol}&tsym=USD&limit=${limit}`
+  );
+  if (!res.ok) {
+    console.log("!res.ok");
+    throw new Error("Error: something went wrong, please try again later 😢");
+  }
+
+  const data = await res.json();
+  if (data?.Response !== "Success" || !data?.Data) {
+    console.log('data?.Response !== "Success" || !data?.Data');
+    throw new Error("Sorry! No market data available for this coin 😢");
+  }
+  return data;
+}

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -1,0 +1,15 @@
+export async function getCoinDailyAverageData(coinSymbol) {
+  const res = await fetch(
+    `https://min-api.cryptocompare.com/data/generateAvg?fsym=${coinSymbol}&tsym=USD&e=Kraken`
+  );
+
+  if (!res.ok) {
+    throw new Error("Error: something went wrong, please try again later 😢");
+  }
+
+  const data = await res.json();
+  if ((data?.Response && data.Response === "Error") || !data?.DISPLAY) {
+    throw new Error("Sorry! No market data available for this coin 😢");
+  }
+  return data;
+}

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -34,7 +34,7 @@ export async function getAllCoins() {
     "https://min-api.cryptocompare.com/data/all/coinlist?summary=true"
   );
   if (!res.ok) {
-    throw new Error("Error: failed to fetch coins, please try again later");
+    throw new Error("Error: something went wrong, please try again later 😢");
   }
 
   const body = await res.json();
@@ -44,7 +44,7 @@ export async function getAllCoins() {
   return body.Data;
 }
 
-export async function getCoinSummary({ fromSymbol }) {
+export async function getCoinDetails({ fromSymbol }) {
   const res = await fetch(
     `https://min-api.cryptocompare.com/data/all/coinlist?fsym=${fromSymbol}`
   );

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -53,6 +53,9 @@ export async function getCoinSummary({ fromSymbol }) {
   }
 
   const body = await res.json();
+  if (body?.Response !== "Error" && body?.ParamWithError === "fsym") {
+    throw new Error("A coin with that symbol does not exist");
+  }
   if (body?.Response !== "Success" || !body?.Data) {
     throw new Error("Error: something went wrong, please try again later 😢");
   }

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -11,6 +11,7 @@ export async function getCoinDailyAverageData(coinSymbol) {
   if ((data?.Response && data.Response === "Error") || !data?.DISPLAY) {
     throw new Error("Sorry! No market data available for this coin 😢");
   }
+
   return data;
 }
 
@@ -19,14 +20,13 @@ export async function getCoinHistory({ coinSymbol, timeUnit, limit }) {
     `https://min-api.cryptocompare.com/data/${timeUnit}?fsym=${coinSymbol}&tsym=USD&limit=${limit}`
   );
   if (!res.ok) {
-    console.log("!res.ok");
     throw new Error("Error: something went wrong, please try again later 😢");
   }
 
   const data = await res.json();
   if (data?.Response !== "Success" || !data?.Data) {
-    console.log('data?.Response !== "Success" || !data?.Data');
     throw new Error("Sorry! No market data available for this coin 😢");
   }
+
   return data;
 }

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -31,14 +31,34 @@ export async function getCoinHistory({ fromSymbol, timeUnit, limit }) {
 
 export async function getAllCoins() {
   const res = await fetch(
-    "https://min-api.cryptocompare.com/data/all/coinlist"
+    "https://min-api.cryptocompare.com/data/all/coinlist?summary=true"
   );
   if (!res.ok) {
     throw new Error("Error: failed to fetch coins, please try again later");
   }
+
   const body = await res.json();
   if (body?.Response !== "Success" || !body?.Data) {
     throw new Error("Error: failed to fetch coins, please try again later");
   }
   return body.Data;
+}
+
+export async function getCoinSummary({ fromSymbol }) {
+  const res = await fetch(
+    `https://min-api.cryptocompare.com/data/all/coinlist?fsym=${fromSymbol}`
+  );
+  if (!res.ok) {
+    throw new Error("Error: something went wrong, please try again later 😢");
+  }
+
+  const body = await res.json();
+  if (body?.Response !== "Success" || !body?.Data) {
+    throw new Error("Error: something went wrong, please try again later 😢");
+  }
+  if (!(fromSymbol in body.Data)) {
+    throw new Error("Error: something went wrong, please try again later 😢");
+  }
+
+  return body.Data[fromSymbol];
 }

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -1,17 +1,17 @@
-export async function getCoinDailyAverageData({ fromSymbol }) {
+export async function getCoinDisplayData({ fromSymbol }) {
   const res = await fetch(
-    `https://min-api.cryptocompare.com/data/generateAvg?fsym=${fromSymbol}&tsym=USD&e=Kraken`
+    `https://min-api.cryptocompare.com/data/generateAvg?fsym=${fromSymbol}&tsym=USD&e=CCCAGG`
   );
   if (!res.ok) {
     throw new Error("Error: something went wrong, please try again later 😢");
   }
 
-  const data = await res.json();
-  if ((data?.Response && data.Response === "Error") || !data?.DISPLAY) {
+  const body = await res.json();
+  if ((body?.Response && body.Response === "Error") || !body?.DISPLAY) {
     throw new Error("Sorry! No market data available for this coin 😢");
   }
 
-  return data;
+  return body.DISPLAY;
 }
 
 export async function getCoinHistory({ fromSymbol, timeUnit, limit }) {
@@ -22,9 +22,9 @@ export async function getCoinHistory({ fromSymbol, timeUnit, limit }) {
     throw new Error("Error: something went wrong, please try again later 😢");
   }
 
-  const data = await res.json();
-  if (data?.Response !== "Success" || !data?.Data) {
+  const body = await res.json();
+  if (body?.Response !== "Success" || !body?.Data) {
     throw new Error("Sorry! No market data available for this coin 😢");
   }
-  return data;
+  return body.Data;
 }

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -1,6 +1,6 @@
-export async function getCoinDailyAverageData(coinSymbol) {
+export async function getCoinDailyAverageData({ fromSymbol }) {
   const res = await fetch(
-    `https://min-api.cryptocompare.com/data/generateAvg?fsym=${coinSymbol}&tsym=USD&e=Kraken`
+    `https://min-api.cryptocompare.com/data/generateAvg?fsym=${fromSymbol}&tsym=USD&e=Kraken`
   );
   if (!res.ok) {
     throw new Error("Error: something went wrong, please try again later 😢");
@@ -14,9 +14,9 @@ export async function getCoinDailyAverageData(coinSymbol) {
   return data;
 }
 
-export async function getCoinHistory({ coinSymbol, timeUnit, limit }) {
+export async function getCoinHistory({ fromSymbol, timeUnit, limit }) {
   const res = await fetch(
-    `https://min-api.cryptocompare.com/data/${timeUnit}?fsym=${coinSymbol}&tsym=USD&limit=${limit}`
+    `https://min-api.cryptocompare.com/data/${timeUnit}?fsym=${fromSymbol}&tsym=USD&limit=${limit}`
   );
   if (!res.ok) {
     throw new Error("Error: something went wrong, please try again later 😢");

--- a/client/src/lib/cryptocompareAPI.js
+++ b/client/src/lib/cryptocompareAPI.js
@@ -28,3 +28,17 @@ export async function getCoinHistory({ fromSymbol, timeUnit, limit }) {
   }
   return body.Data;
 }
+
+export async function getAllCoins() {
+  const res = await fetch(
+    "https://min-api.cryptocompare.com/data/all/coinlist"
+  );
+  if (!res.ok) {
+    throw new Error("Error: failed to fetch coins, please try again later");
+  }
+  const body = await res.json();
+  if (body?.Response !== "Success" || !body?.Data) {
+    throw new Error("Error: failed to fetch coins, please try again later");
+  }
+  return body.Data;
+}

--- a/client/src/lib/transformers.js
+++ b/client/src/lib/transformers.js
@@ -1,0 +1,25 @@
+export function parseCoinDisplayData(coinDisplayData) {
+  const {
+    PRICE,
+    CHANGEPCT24HOUR,
+    OPEN24HOUR,
+    HIGH24HOUR,
+    LOW24HOUR,
+    CHANGE24HOUR,
+  } = coinDisplayData;
+  return {
+    currentPrice: PRICE,
+    pctChange: CHANGEPCT24HOUR,
+    open: OPEN24HOUR,
+    high: HIGH24HOUR,
+    low: LOW24HOUR,
+    usdChange: CHANGE24HOUR,
+  };
+}
+
+export function parseHistoryIntoCoordinates(history) {
+  return history.map((historicalPoint) => ({
+    time: historicalPoint.time,
+    price: historicalPoint.close,
+  }));
+}

--- a/client/src/lib/transformers.js
+++ b/client/src/lib/transformers.js
@@ -23,3 +23,7 @@ export function parseHistoryIntoCoordinates(history) {
     price: historicalPoint.close,
   }));
 }
+
+export function parseAllCoinSymbols(allCoins) {
+  return Object.values(allCoins);
+}


### PR DESCRIPTION
Refactor all cryptocompare API calls into their own file: `lib/cryptocompareAPI.js`
- renamed a bunch of variable names
- made a module for transforming  CCCAGG API response data

refactored CCCAGG API fetchs out of:
- history slice
- coinList slice and watchList slice
- symbols slice


Also updated manifest.json