### PR TITLE
fix bug: mongodb duplicate username key

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -69,6 +69,7 @@ const googleAuth = async () => {
               email: profile.emails[0].value,
               name: profile.displayName,
               googleid: profile.id,
+              username: email,
             },
             function (err, user) {
               return cb(err, user);
@@ -98,6 +99,7 @@ const facebookAuth = async () => {
               email: profile.emails[0].value,
               name: profile.name.givenName,
               facebookid: profile.id,
+              username: email,
             },
             function (err, user) {
               return cb(err, user);

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -22,6 +22,7 @@ const registerUser = async (req, res) => {
       email,
       password,
       watchlist: [],
+      username: email,
     });
     const user = await User.addUser(newUser);
     const token = createToken({ _id: user._id });


### PR DESCRIPTION
This was caused by `passport-local-mongoose` including a required unique username field in the user schema...

I fixed it by making sure every newly registered user includes a unique `username` field.