### PR TITLE
Bump axios 1.15.2 to 1.16.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "@reduxjs/toolkit": "^1.9.7",
         "@vitejs/plugin-react": "^4.3.4",
         "altcoin-charter": "file:..",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "bootstrap": "^5.3.3",
         "dotenv": "^16.3.1",
         "email-validator": "^2.0.4",
@@ -33,7 +33,6 @@
       }
     },
     "..": {
-      "name": "altcoin-charter",
       "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
@@ -1542,6 +1541,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1794,13 +1805,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3158,9 +3170,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3530,6 +3542,19 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ignore": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "@reduxjs/toolkit": "^1.9.7",
     "@vitejs/plugin-react": "^4.3.4",
     "altcoin-charter": "file:..",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "bootstrap": "^5.3.3",
     "dotenv": "^16.3.1",
     "email-validator": "^2.0.4",


### PR DESCRIPTION
This PR fixes the `follow-redirects` security vulnerability: https://github.com/LoTerence/altcoin-charter/security/dependabot/232

Root cause
- `follow-redirects` is a downstream dependency of axios 1.15.2
- Upgrading axios to the newest version fixes this issue

Notes
- Upgrading from axios 1.15.2 to 1.16.1 does not effect my axios implementation
- It goes from 1.15.2 -> 1.16.0 -> 1.16.1, so there are only two releases to review
- 1.16.0 has some new features and changes to be mindful of, but does not effect my use of axios
- 1.16.1 has bugfixes and security patches

References
- https://github.com/axios/axios/releases
- https://github.com/axios/axios/releases/tag/v1.16.0
- https://github.com/axios/axios/releases/tag/v1.16.1